### PR TITLE
Update whitelist.md

### DIFF
--- a/whitelist.md
+++ b/whitelist.md
@@ -4,7 +4,6 @@ This list is for companies who have stood up to Chinese censorship demands and r
 
 | Name of Company | Date Added | Why added | Sources |
 | --------------- | ---------- | --------- | ------- |
-| ~~Red Bull~~ | 2019-10-09 | ~~Released advertisment supportive of the Hong Kong protests~~ As of 2019-10-10 I have not been able to verify the authenticity of this red bull entry, and I have not seen it mentioned in the media. Striking through until I can get more details | http://sendvid.com/q6xdrgrn |
 | Matt Stone & Trey Parker (Comedy Central) | 2019-10-09 | Released South Park episode mocking Chinese censorship, causing show to be censored in China, then issuing a mock apology | https://www.bbc.co.uk/news/world-asia-china-49968867 |
 | Ubisoft | 2019-10-09 | Refused to implement aesthetic changes ordered by China to game, however this was a U-Turn following an earlier decision to comply | https://www.windowscentral.com/rainbow-six-siege-drops-china-censorship-reverts-aesthetic-changes |
 | Prague City Council | 2019-10-09 | Canceled sister city agreement with Beijing after China refused to remove clause in agreement which stipulated that the council must support the "one-china" principle | https://www.scmp.com/news/china/diplomacy/article/3032045/prague-cuts-sister-city-ties-beijing-amid-tangible-anger-over |


### PR DESCRIPTION
It appears that the Red Bull ad being showcased was ran (possibly inclusively) in Italy. I don't believe that it was ran recently to support Hong Kong. There are rumors about it being used to support Taiwan, but I haven't been able to find any evidence for that either. I'm inclined to think it's not intended for Taiwan or Hong Kong because the ad looks to have been run in early 2019, before the situation in Hong Kong was as developed, and years after the turn of Taiwan.

Sources:
- https://video.repubblica.it/spettacoli-e-cultura/poliziotti-contro-lo-spot-della-red-bull-ci-criminalizza-non-e-satira/329990/330591
- https://youtu.be/QIMDlCqBGVk
- https://www.youtg.net/v3/canali/in-sardegna/15255-cagliari-sindacati-di-polizia-contro-red-bull-lo-spot-istiga-all-odio-contro-le-forze-dell-ordine